### PR TITLE
Feature/add readme

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -31,4 +31,5 @@ jobs:
       - name: Run Utils checks
         run: |
           pip install .
+          pip install .[automation]
           pytest --rootdir=./tests ./tests/

--- a/src/ensembl/datacheck/checks/automation/README.md
+++ b/src/ensembl/datacheck/checks/automation/README.md
@@ -1,0 +1,58 @@
+# Automation Checks: How To Run
+
+This directory contains automation datachecks under:
+
+- `src/ensembl/datacheck/checks/automation`
+
+## 1) Prerequisites
+
+From the repository root:
+
+```bash
+python -m pip install -e ".[automation]"
+```
+
+Set required inputs:
+
+```bash
+export AUTOMATION_CONFIG="src/ensembl/datacheck/checks/automation/resource_config.json"
+export METADATA_DB_URL="mysql+pymysql://<user>:<pass>@<host>/<db>"
+export TAXONOMY_DB_URL="mysql+pymysql://<user>:<pass>@<host>/<db>"
+```
+
+Optional filters (recommended to narrow scope):
+
+```bash
+export RELEASE_NAME="<release_name>"
+export GENOME_UUID="<genome_uuid>"
+```
+
+Build shared CLI args:
+
+```bash
+COMMON_ARGS="--database ${METADATA_DB_URL} --taxonomy_database ${TAXONOMY_DB_URL} --automation_resource_config ${AUTOMATION_CONFIG}"
+COMMON_ARGS="${COMMON_ARGS} --release_name ${RELEASE_NAME} --genome_uuid ${GENOME_UUID}"
+```
+
+## 2) Run each automation test module
+
+```bash
+ensembl-datacheck --test=automation/automation_blast_expected_files ${COMMON_ARGS}
+ensembl-datacheck --test=automation/automation_compara_mongo_load ${COMMON_ARGS}
+ensembl-datacheck --test=automation/automation_ftp_expected_files ${COMMON_ARGS}
+ensembl-datacheck --test=automation/automation_genesearch_expected_file ${COMMON_ARGS}
+ensembl-datacheck --test=automation/automation_genome_browser_files_expected_files ${COMMON_ARGS}
+ensembl-datacheck --test=automation/automation_refget_expected_files ${COMMON_ARGS}
+ensembl-datacheck --test=automation/automation_thoas_mongo_load ${COMMON_ARGS}
+```
+
+## 3) Run all automation tests
+
+```bash
+ensembl-datacheck --test=automation ${COMMON_ARGS}
+```
+
+## Notes
+
+- `--test=automation` runs every `*.py` module in this directory (excluding `conftest.py`).
+- Mongo-related checks use URIs from `resource_config.json` (`compara_mongo_uri`, `thoas_mongo_*`).

--- a/src/ensembl/datacheck/checks/automation/automation_blast_expected_files.py
+++ b/src/ensembl/datacheck/checks/automation/automation_blast_expected_files.py
@@ -22,6 +22,7 @@ Checks performed:
 """
 
 import pytest
+from pathlib import Path
 from ensembl.datacheck.checks.automation.utils import validate_expected_files
 
 
@@ -44,9 +45,14 @@ def check_blast_expected_files(genomes, automation_resource_config):
     assert expected_files, "Missing blast.expected_files in automation resource config."
 
     genome_uuid = genomes["genome_uuid"]
+    release_name = genomes.get("release_name")
+    assert release_name is not None, f"Missing release_name for genome_uuid={genome_uuid}"
+
+
+
     validate_expected_files(
         base_path=base_path,
-        relative_path=genome_uuid,
+        relative_path=Path(f"release_{release_name}") / genome_uuid,
         expected_files=expected_files,
         resource_label=f"BLAST (genome_uuid={genome_uuid})",
     )

--- a/src/ensembl/datacheck/checks/automation/automation_ftp_expected_files.py
+++ b/src/ensembl/datacheck/checks/automation/automation_ftp_expected_files.py
@@ -44,6 +44,14 @@ def _check_ftp_resource(user_cli, genomes,  automation_resource_config, resource
 
     metadata_db_uri = user_cli.getoption("--database")
     taxonomy_db_uri = user_cli.getoption("--taxonomy_database")
+    assert metadata_db_uri, (
+        "Missing --database for FTP automation checks. "
+        "Provide metadata DB URL (e.g. --database mysql+pymysql://user:pass@host/db)."
+    )
+    assert taxonomy_db_uri, (
+        "Missing --taxonomy_database for FTP automation checks. "
+        "Provide taxonomy DB URL (e.g. --taxonomy_database mysql+pymysql://user:pass@host/db)."
+    )
 
     ftp_paths = get_ftp_paths(metadata_uri=metadata_db_uri, taxonomy_uri=taxonomy_db_uri, genome_uuid=genomes['genome_uuid'])
 
@@ -60,7 +68,7 @@ def _check_ftp_resource(user_cli, genomes,  automation_resource_config, resource
 @pytest.mark.automation_resource("ftp_dumps_geneset")
 def check_ftp_dumps_geneset_expected_files(user_cli, genomes, automation_resource_config):
     """Validate expected files for ftp_dumps_geneset."""
-    _check_ftp_resource(genomes, automation_resource_config, "ftp_dumps_geneset", 'genebuild')
+    _check_ftp_resource(user_cli, genomes, automation_resource_config, "ftp_dumps_geneset", 'genebuild')
 
 
 @pytest.mark.automation_resource("all")
@@ -92,4 +100,4 @@ def check_ftp_dumps_vep_geneset_expected_files(user_cli, genomes, automation_res
 @pytest.mark.automation_resource("ftp_dumps_vep_genome")
 def check_ftp_dumps_vep_genome_expected_files(user_cli, genomes, automation_resource_config):
     """Validate expected files for ftp_dumps_vep_genome."""
-    _check_ftp_resource(user_cli, genomes, automation_resource_config, "ftp_dumps_vep_genome", 'genebuild')
+    _check_ftp_resource(user_cli, genomes, automation_resource_config, "ftp_dumps_vep_genome", 'assembly')

--- a/src/ensembl/datacheck/checks/automation/automation_ftp_expected_files.py
+++ b/src/ensembl/datacheck/checks/automation/automation_ftp_expected_files.py
@@ -23,6 +23,7 @@ Checks performed:
 
 """
 
+import logging
 
 import pytest
 from ensembl.datacheck.checks.automation.utils import validate_expected_files
@@ -53,11 +54,15 @@ def _check_ftp_resource(user_cli, genomes,  automation_resource_config, resource
         "Provide taxonomy DB URL (e.g. --taxonomy_database mysql+pymysql://user:pass@host/db)."
     )
 
-    ftp_paths = get_ftp_paths(
-        metadata_uri=metadata_db_uri,
-        taxonomy_uri=taxonomy_db_uri,
-        genome_uuid=genomes["genome_uuid"],
-    )
+    get_ftp_paths_kwargs = {
+        "metadata_uri": metadata_db_uri,
+        "taxonomy_uri": taxonomy_db_uri,
+        "genome_uuid": genomes["genome_uuid"],
+    }
+    if dataset_name.startswith("vep"):
+        get_ftp_paths_kwargs["dataset_name"] = dataset_name
+
+    ftp_paths = get_ftp_paths(**get_ftp_paths_kwargs)
     if isinstance(ftp_paths, dict):
         ftp_paths_by_dataset = ftp_paths
     else:
@@ -108,7 +113,7 @@ def check_ftp_dumps_homology_expected_files(user_cli, genomes, automation_resour
 @pytest.mark.automation_resource("ftp_dumps_vep_geneset")
 def check_ftp_dumps_vep_geneset_expected_files(user_cli, genomes, automation_resource_config):
     """Validate expected files for ftp_dumps_vep_geneset."""
-    _check_ftp_resource(user_cli, genomes,  automation_resource_config, "ftp_dumps_vep_geneset", 'genebuild')
+    _check_ftp_resource(user_cli, genomes,  automation_resource_config, "ftp_dumps_vep_geneset", 'vep_gff_location')
 
 
 @pytest.mark.automation_resource("all")
@@ -116,4 +121,5 @@ def check_ftp_dumps_vep_geneset_expected_files(user_cli, genomes, automation_res
 @pytest.mark.automation_resource("ftp_dumps_vep_genome")
 def check_ftp_dumps_vep_genome_expected_files(user_cli, genomes, automation_resource_config):
     """Validate expected files for ftp_dumps_vep_genome."""
-    _check_ftp_resource(user_cli, genomes, automation_resource_config, "ftp_dumps_vep_genome", 'assembly')
+    logging.info("Starting check for ftp_dumps_vep_genome expected files for genome_uuid=%s", genomes['genome_uuid'])
+    _check_ftp_resource(user_cli, genomes, automation_resource_config, "ftp_dumps_vep_genome", 'vep_faa_location')

--- a/src/ensembl/datacheck/checks/automation/automation_ftp_expected_files.py
+++ b/src/ensembl/datacheck/checks/automation/automation_ftp_expected_files.py
@@ -53,11 +53,27 @@ def _check_ftp_resource(user_cli, genomes,  automation_resource_config, resource
         "Provide taxonomy DB URL (e.g. --taxonomy_database mysql+pymysql://user:pass@host/db)."
     )
 
-    ftp_paths = get_ftp_paths(metadata_uri=metadata_db_uri, taxonomy_uri=taxonomy_db_uri, genome_uuid=genomes['genome_uuid'])
+    ftp_paths = get_ftp_paths(
+        metadata_uri=metadata_db_uri,
+        taxonomy_uri=taxonomy_db_uri,
+        genome_uuid=genomes["genome_uuid"],
+    )
+    if isinstance(ftp_paths, dict):
+        ftp_paths_by_dataset = ftp_paths
+    else:
+        ftp_paths_by_dataset = {
+            item["dataset_type"]: item["path"]
+            for item in ftp_paths
+            if isinstance(item, dict) and "dataset_type" in item and "path" in item
+        }
+    assert dataset_name in ftp_paths_by_dataset, (
+        f"Dataset type '{dataset_name}' not found in metadata public paths for "
+        f"genome_uuid={genomes['genome_uuid']}. Available: {sorted(ftp_paths_by_dataset)}"
+    )
 
     validate_expected_files(
         base_path=base_path,
-        relative_path=ftp_paths[dataset_name],
+        relative_path=ftp_paths_by_dataset[dataset_name],
         expected_files=expected_files,
         resource_label=f"{resource_key} (genome_uuid={genomes['genome_uuid']})",
     )

--- a/src/ensembl/datacheck/checks/automation/automation_genesearch_expected_file.py
+++ b/src/ensembl/datacheck/checks/automation/automation_genesearch_expected_file.py
@@ -36,7 +36,10 @@ def check_genesearch_expected_file(genomes, automation_resource_config):
     assert base_path, "Missing genesearch.base_path in automation resource config."
 
     genome_uuid = genomes["genome_uuid"]
-    genesearch_file = Path(base_path) / f"{genome_uuid}_toplevel_solr.json"
+    release_name = genomes.get("release_name")
+    assert release_name is not None, f"Missing release_name for genome_uuid={genome_uuid}"
+
+    genesearch_file = Path(base_path)/ release_name / f"{genome_uuid}_toplevel_solr.json"
     assert genesearch_file.is_file(), (
         f"genesearch file does not exist for genome_uuid={genome_uuid}: {genesearch_file}"
     )

--- a/src/ensembl/datacheck/checks/automation/automation_genesearch_expected_file.py
+++ b/src/ensembl/datacheck/checks/automation/automation_genesearch_expected_file.py
@@ -39,7 +39,7 @@ def check_genesearch_expected_file(genomes, automation_resource_config):
     release_name = genomes.get("release_name")
     assert release_name is not None, f"Missing release_name for genome_uuid={genome_uuid}"
 
-    genesearch_file = Path(base_path)/ release_name / f"{genome_uuid}_toplevel_solr.json"
+    genesearch_file = Path(base_path)/ Path(f"release_{release_name}") / f"{genome_uuid}_toplevel_solr.json"
     assert genesearch_file.is_file(), (
         f"genesearch file does not exist for genome_uuid={genome_uuid}: {genesearch_file}"
     )

--- a/src/ensembl/datacheck/checks/automation/automation_genome_browser_files_expected_files.py
+++ b/src/ensembl/datacheck/checks/automation/automation_genome_browser_files_expected_files.py
@@ -26,6 +26,33 @@ import pytest
 from ensembl.datacheck.checks.automation.utils import validate_expected_files
 
 
+def _resolve_genome_browser_relative_path(base_path, release_name, genome_uuid):
+    """Resolve genome browser path, allowing an optional one-level subdirectory under release."""
+    base = Path(base_path)
+    release_root_relative = Path(f"release_{release_name}")
+    release_root = base / release_root_relative
+    assert release_root.is_dir(), f"Release directory does not exist: {release_root}"
+
+    direct_relative = release_root_relative / genome_uuid
+    if (base / direct_relative).is_dir():
+        return direct_relative
+
+    nested_candidates = sorted(
+        candidate.relative_to(base)
+        for candidate in release_root.glob(f"*/{genome_uuid}")
+        if candidate.is_dir()
+    )
+    assert nested_candidates, (
+        f"genome_browser_files path does not exist for genome_uuid={genome_uuid} "
+        f"under {release_root} (checked direct and one-level nested directories)"
+    )
+    assert len(nested_candidates) == 1, (
+        f"Multiple genome_browser_files directories found for genome_uuid={genome_uuid}: "
+        f"{[str(path) for path in nested_candidates]}"
+    )
+    return nested_candidates[0]
+
+
 @pytest.mark.automation_resource("all")
 @pytest.mark.automation_resource("genome_browser_files")
 def check_genome_browser_files_expected_files(genomes, automation_resource_config):
@@ -42,10 +69,15 @@ def check_genome_browser_files_expected_files(genomes, automation_resource_confi
     genome_uuid = genomes["genome_uuid"]
     release_name = genomes.get("release_name")
     assert release_name is not None, f"Missing release_name for genome_uuid={genome_uuid}"
+    relative_path = _resolve_genome_browser_relative_path(
+        base_path=base_path,
+        release_name=release_name,
+        genome_uuid=genome_uuid,
+    )
 
     validate_expected_files(
         base_path=base_path,
-        relative_path=Path(f"release_{release_name}") / genome_uuid,
+        relative_path=relative_path,
         expected_files=expected_files,
         resource_label=f"genome_browser_files (release={release_name}, genome_uuid={genome_uuid})",
     )

--- a/src/ensembl/datacheck/checks/automation/automation_genome_browser_files_expected_files.py
+++ b/src/ensembl/datacheck/checks/automation/automation_genome_browser_files_expected_files.py
@@ -25,6 +25,49 @@ from pathlib import Path
 import pytest
 from ensembl.datacheck.checks.automation.utils import validate_expected_files
 
+ALLOWED_GENOME_BROWSER_FILE_ENDINGS = {
+    ".hashes",
+    ".hashes.ncd",
+    ".sizes",
+    ".sizes.ncd",
+    ".bb",
+    ".bed",
+    ".bw",
+    ".wig",
+    ".txt",
+    ".ncd",
+}
+
+
+def _validate_only_allowed_genome_browser_extensions(base_path, relative_path, resource_label):
+    """Fail if any file has an extension not in ALLOWED_GENOME_BROWSER_FILE_ENDINGS."""
+    resource_path = Path(base_path) / relative_path
+    unexpected_files = sorted(
+        file_path.relative_to(resource_path).as_posix()
+        for file_path in resource_path.rglob("*")
+        if file_path.is_file()
+        and not any(file_path.name.endswith(ending) for ending in ALLOWED_GENOME_BROWSER_FILE_ENDINGS)
+    )
+    assert not unexpected_files, (
+        f"Unexpected {resource_label} files with disallowed extensions in {resource_path}: "
+        f"{unexpected_files}"
+    )
+
+
+def _validate_required_genome_browser_extensions_present(base_path, relative_path, resource_label):
+    """Fail if any required extension from ALLOWED_GENOME_BROWSER_FILE_ENDINGS is absent."""
+    resource_path = Path(base_path) / relative_path
+    file_names = [file_path.name for file_path in resource_path.rglob("*") if file_path.is_file()]
+    present_endings = {
+        ending
+        for ending in ALLOWED_GENOME_BROWSER_FILE_ENDINGS
+        if any(name.endswith(ending) for name in file_names)
+    }
+    missing_endings = sorted(ALLOWED_GENOME_BROWSER_FILE_ENDINGS - present_endings)
+    assert not missing_endings, (
+        f"Missing {resource_label} required file extensions in {resource_path}: {missing_endings}"
+    )
+
 
 def _resolve_genome_browser_relative_path(base_path, release_name, genome_uuid):
     """Resolve genome browser path, allowing an optional one-level subdirectory under release."""
@@ -79,5 +122,15 @@ def check_genome_browser_files_expected_files(genomes, automation_resource_confi
         base_path=base_path,
         relative_path=relative_path,
         expected_files=expected_files,
+        resource_label=f"genome_browser_files (release={release_name}, genome_uuid={genome_uuid})",
+    )
+    _validate_only_allowed_genome_browser_extensions(
+        base_path=base_path,
+        relative_path=relative_path,
+        resource_label=f"genome_browser_files (release={release_name}, genome_uuid={genome_uuid})",
+    )
+    _validate_required_genome_browser_extensions_present(
+        base_path=base_path,
+        relative_path=relative_path,
         resource_label=f"genome_browser_files (release={release_name}, genome_uuid={genome_uuid})",
     )

--- a/src/ensembl/datacheck/checks/automation/automation_refget_expected_files.py
+++ b/src/ensembl/datacheck/checks/automation/automation_refget_expected_files.py
@@ -25,6 +25,50 @@ from pathlib import Path
 from ensembl.datacheck.checks.automation.utils import validate_expected_files
 
 
+def _validate_only_expected_refget_files(base_path, relative_path, expected_files, resource_label):
+    """Fail if any file other than expected_files exists under the resolved refget path."""
+    resource_path = Path(base_path) / relative_path
+
+    expected_set = {Path(path).as_posix() for path in expected_files}
+    actual_set = {
+        file_path.relative_to(resource_path).as_posix()
+        for file_path in resource_path.rglob("*")
+        if file_path.is_file()
+    }
+
+    unexpected_files = sorted(actual_set - expected_set)
+    assert not unexpected_files, (
+        f"Unexpected {resource_label} files in {resource_path}: {unexpected_files}"
+    )
+
+
+def _resolve_refget_relative_path(base_path, release_name, genome_uuid):
+    """Resolve refget path, allowing an optional one-level subdirectory under release."""
+    base = Path(base_path)
+    release_root_relative = Path(f"release_{release_name}")
+    release_root = base / release_root_relative
+    assert release_root.is_dir(), f"Release directory does not exist: {release_root}"
+
+    direct_relative = release_root_relative / genome_uuid
+    if (base / direct_relative).is_dir():
+        return direct_relative
+
+    nested_candidates = sorted(
+        candidate.relative_to(base)
+        for candidate in release_root.glob(f"*/{genome_uuid}")
+        if candidate.is_dir()
+    )
+    assert nested_candidates, (
+        f"refget path does not exist for genome_uuid={genome_uuid} "
+        f"under {release_root} (checked direct and one-level nested directories)"
+    )
+    assert len(nested_candidates) == 1, (
+        f"Multiple refget directories found for genome_uuid={genome_uuid}: "
+        f"{[str(path) for path in nested_candidates]}"
+    )
+    return nested_candidates[0]
+
+
 @pytest.mark.automation_resource("all")
 @pytest.mark.automation_resource("refget")
 def check_refget_expected_files(genomes, automation_resource_config):
@@ -41,10 +85,21 @@ def check_refget_expected_files(genomes, automation_resource_config):
     genome_uuid = genomes["genome_uuid"]
     release_name = genomes.get("release_name")
     assert release_name is not None, f"Missing release_name for genome_uuid={genome_uuid}"
+    relative_path = _resolve_refget_relative_path(
+        base_path=base_path,
+        release_name=release_name,
+        genome_uuid=genome_uuid,
+    )
 
     validate_expected_files(
         base_path=base_path,
-        relative_path=Path(f"release_{release_name}") / genome_uuid,
+        relative_path=relative_path,
+        expected_files=expected_files,
+        resource_label=f"refget (release={release_name}, genome_uuid={genome_uuid})",
+    )
+    _validate_only_expected_refget_files(
+        base_path=base_path,
+        relative_path=relative_path,
         expected_files=expected_files,
         resource_label=f"refget (release={release_name}, genome_uuid={genome_uuid})",
     )

--- a/src/ensembl/datacheck/checks/automation/automation_track_api_load.py
+++ b/src/ensembl/datacheck/checks/automation/automation_track_api_load.py
@@ -1,0 +1,124 @@
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Check that track API track_categories endpoint is reachable
+for both staging and production environments.
+
+Checks performed:
+    - Check track_categories endpoint returns HTTP 200
+    - Check expected track category IDs are present
+"""
+import logging
+
+import requests
+import pytest
+
+EXPECTED_TRACK_CATEGORY_IDS = {"genes-transcripts", "assembly"}
+
+
+def _get_track_category_ids(payload):
+    """Extract track category IDs from a Track API response payload."""
+    track_categories = payload.get("track_categories", ['genes-transcripts','assembly'])
+    assert isinstance(track_categories, list), "Track API response field 'track_categories' is not a list."
+
+    return {
+        category.get("track_category_id")
+        for category in track_categories
+        if isinstance(category, dict)
+    }
+
+
+@pytest.mark.automation_resource("all")
+@pytest.mark.automation_resource("track_api")
+@pytest.mark.parametrize(
+    "track_api_resource",
+    [
+        "track_api_stage",
+        "track_api_prod",
+    ],
+    indirect=True
+)
+class TestTrackCategoriesEndpoint:
+    """
+    Check track_categories endpoint for stage and prod.
+    """
+
+    endpoint = "/api/tracks/track_categories"
+
+    @pytest.fixture(autouse=True)
+    def setup(self, genomes, track_api_resource):
+        """
+        Prepare commonly used attributes for each test invocation.
+        """
+
+        self.genome_uuid = genomes["genome_uuid"]
+        self.base_url = track_api_resource.rstrip("/")
+
+    def _get_track_categories_response(self):
+        url = f"{self.base_url}{self.endpoint}/{self.genome_uuid}"
+
+        logging.info(f"Checking track categories endpoint for genome UUID: {self.genome_uuid}")
+        logging.info(f"URL: {url}")
+
+        return requests.get(url, timeout=30)
+
+    def check_track_categories_status_code(self):
+        """
+        Check track_categories endpoint returns HTTP 200.
+
+        Raises:
+            AssertionError:
+                If endpoint does not return status code 200.
+        """
+
+        response = self._get_track_categories_response()
+
+        if response.status_code != 200:
+            raise AssertionError(
+                f"Track API endpoint failed for URL: {response.url} "
+                f"with status code: {response.status_code}"
+            )
+
+    def check_track_categories_expected_category_ids(self):
+        """
+        Check that expected track category IDs exist in the response.
+
+        Raises:
+            AssertionError:
+                If the response does not include the expected category IDs.
+        """
+        response = self._get_track_categories_response()
+
+        if response.status_code != 200:
+            raise AssertionError(
+                f"Track API endpoint failed for URL: {response.url} "
+                f"with status code: {response.status_code}"
+            )
+
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            raise AssertionError(
+                f"Track API endpoint did not return valid JSON for URL: {response.url}"
+            ) from exc
+
+        category_ids = _get_track_category_ids(payload)
+        missing_category_ids = EXPECTED_TRACK_CATEGORY_IDS - category_ids
+
+        assert not missing_category_ids, (
+            "Missing expected track category IDs: "
+            f"{sorted(missing_category_ids)}. Found: {sorted(category_ids)}"
+        )

--- a/src/ensembl/datacheck/checks/automation/conftest.py
+++ b/src/ensembl/datacheck/checks/automation/conftest.py
@@ -85,6 +85,29 @@ def automation_resource_config(request):
 
 
 @pytest.fixture(scope="session")
+def track_api_resource(request, automation_resource_config):
+    """
+    Return a Track API base URI for the parametrized resource type.
+    """
+    resource_type = getattr(request, "param", None)
+    if not resource_type:
+        raise ValueError("Please parametrize the track_api_resource fixture with a resource type")
+
+    resource = automation_resource_config.get(resource_type)
+    if not resource:
+        pytest.skip(f"Resource '{resource_type}' not found in config file")
+
+    if resource.get("ignore") == "True":
+        pytest.skip(f"Skipped '{resource_type}' check as ignore=True in config")
+
+    uri = resource.get("uri")
+    if not uri:
+        pytest.skip(f"Track API URI missing for '{resource_type}'")
+
+    return uri
+
+
+@pytest.fixture(scope="session")
 def mongo_client(request, automation_resource_config):
     """
     Returns a MongoClient for a specific resource type.
@@ -112,4 +135,3 @@ def mongo_client(request, automation_resource_config):
 
     # Cleanup
     client.close()
-

--- a/src/ensembl/datacheck/checks/automation/resource_config.json
+++ b/src/ensembl/datacheck/checks/automation/resource_config.json
@@ -63,6 +63,14 @@
           "ignore": "True",
           "uri": ""
         },
+        "track_api_stage": {
+            "ignore": "True",
+            "uri": ""
+        },
+        "track_api_prod": {
+            "ignore": "True",
+            "uri": ""
+        },
         "compara_dev": {
           "ignore": "True",
           "uri": ""

--- a/src/ensembl/datacheck/checks/automation/utils.py
+++ b/src/ensembl/datacheck/checks/automation/utils.py
@@ -22,15 +22,22 @@ The module ensures that all specified files, including those that match
 wildcard patterns, are present in the specified directory. If any files are
 missing, an assertion is raised indicating the missing files.
 """
-
-
+import logging
 from pathlib import Path
 from ensembl.production.metadata.api.adaptors.genome import GenomeAdaptor
+from ensembl.production.metadata.api.adaptors.vep import  VepAdaptor
 
-def get_ftp_paths(metadata_uri, taxonomy_uri, genome_uuid) :
+def get_ftp_paths(metadata_uri, taxonomy_uri, genome_uuid, dataset_name=None ) :
     """
     Prepare FTP relative paths for the given genome uuid from metadata.
     """
+
+    if dataset_name and dataset_name.startswith("vep") :
+        file_type = dataset_name.split("_", maxsplit=1)[-1] # vep_faa_location is split into ["vep", "faa_location"] and fetch faa_location
+        file_location = VepAdaptor(metadata_uri, file=file_type).fetch_vep_locations(genome_uuid)
+        if isinstance(file_location, dict):
+            file_location = file_location[file_type]
+        return {dataset_name: file_location}
     return GenomeAdaptor(metadata_uri, taxonomy_uri).get_public_path(genome_uuid)
 
 def validate_expected_files(base_path, relative_path, expected_files, resource_label):

--- a/src/ensembl/datacheck/functions/utils.py
+++ b/src/ensembl/datacheck/functions/utils.py
@@ -65,9 +65,10 @@ def get_genomes_from_metadata_db(db_url, release_name=None, genome_uuids:list=No
 
     """
     release_name = release_name.split(',') if release_name else None
+    genome_uuids = genome_uuids if genome_uuids else None
     genomes_iter = GenomeFactory().get_genomes(
                 metadata_db_uri=db_url,
-                genome_uuid=[genome_uuids],
+                genome_uuid=genome_uuids,
                 dataset_type="genebuild",
                 dataset_names=["genebuild"],
                 release_name=release_name,

--- a/src/ensembl/datacheck/functions/utils.py
+++ b/src/ensembl/datacheck/functions/utils.py
@@ -65,7 +65,7 @@ def get_genomes_from_metadata_db(db_url, release_name=None, genome_uuids:list=No
 
     """
     release_name = release_name.split(',') if release_name else None
-    genome_uuids = genome_uuids if genome_uuids else None
+    genome_uuids = genome_uuids.split(',') if genome_uuids else None
     genomes_iter = GenomeFactory().get_genomes(
                 metadata_db_uri=db_url,
                 genome_uuid=genome_uuids,

--- a/src/ensembl/datacheck/functions/utils.py
+++ b/src/ensembl/datacheck/functions/utils.py
@@ -67,7 +67,7 @@ def get_genomes_from_metadata_db(db_url, release_name=None, genome_uuids:list=No
     release_name = release_name.split(',') if release_name else None
     genomes_iter = GenomeFactory().get_genomes(
                 metadata_db_uri=db_url,
-                genome_uuid=genome_uuids,
+                genome_uuid=[genome_uuids],
                 dataset_type="genebuild",
                 dataset_names=["genebuild"],
                 release_name=release_name,

--- a/src/ensembl/datacheck/functions/utils.py
+++ b/src/ensembl/datacheck/functions/utils.py
@@ -51,6 +51,15 @@ class EnsemblDatacheckWarning(UserWarning):
         return f"Warning::{self.file_name}::{self.function_name}: {self.message}"
 
 
+def _normalise_filter_values(values):
+    """Return metadata API filter values from comma-separated strings or iterables."""
+    if not values:
+        return None
+    if isinstance(values, str):
+        return [value.strip() for value in values.split(",") if value.strip()]
+    return list(values)
+
+
 def get_genomes_from_metadata_db(db_url, release_name=None, genome_uuids:list=None):
     """
     Fetch genome UUIDs from database based on release_name or explicit UUID list.
@@ -64,8 +73,8 @@ def get_genomes_from_metadata_db(db_url, release_name=None, genome_uuids:list=No
         pandas.DataFrame: dataframe with genome metadata including uuid
 
     """
-    release_name = release_name.split(',') if release_name else None
-    genome_uuids = genome_uuids.split(',') if genome_uuids else None
+    release_name = _normalise_filter_values(release_name)
+    genome_uuids = _normalise_filter_values(genome_uuids)
     genomes_iter = GenomeFactory().get_genomes(
                 metadata_db_uri=db_url,
                 genome_uuid=genome_uuids,

--- a/tests/test_automation_ftp_expected_files.py
+++ b/tests/test_automation_ftp_expected_files.py
@@ -1,0 +1,92 @@
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for FTP automation checks."""
+
+import pytest
+
+from ensembl.datacheck.checks.automation import automation_ftp_expected_files as ftp_checks
+
+
+class _DummyCli:
+    def __init__(self, options):
+        self._options = options
+
+    def getoption(self, name):
+        return self._options.get(name)
+
+
+def test_check_ftp_resource_accepts_list_of_dataset_paths(monkeypatch):
+    captured = {}
+
+    def _fake_get_ftp_paths(metadata_uri, taxonomy_uri, genome_uuid):
+        assert metadata_uri
+        assert taxonomy_uri
+        assert genome_uuid == "uuid-1"
+        return [{"dataset_type": "genebuild", "path": "species/path/geneset/2026_05"}]
+
+    def _fake_validate_expected_files(base_path, relative_path, expected_files, resource_label):
+        captured["base_path"] = base_path
+        captured["relative_path"] = relative_path
+        captured["expected_files"] = expected_files
+        captured["resource_label"] = resource_label
+
+    monkeypatch.setattr(ftp_checks, "get_ftp_paths", _fake_get_ftp_paths)
+    monkeypatch.setattr(ftp_checks, "validate_expected_files", _fake_validate_expected_files)
+
+    ftp_checks._check_ftp_resource(
+        user_cli=_DummyCli({
+            "--database": "sqlite:///metadata.db",
+            "--taxonomy_database": "sqlite:///taxonomy.db",
+        }),
+        genomes={"genome_uuid": "uuid-1"},
+        automation_resource_config={
+            "ftp_dumps_geneset": {
+                "base_path": "/base",
+                "expected_files": ["cdna.fa.bgz"],
+            }
+        },
+        resource_key="ftp_dumps_geneset",
+        dataset_name="genebuild",
+    )
+
+    assert captured["base_path"] == "/base"
+    assert captured["relative_path"] == "species/path/geneset/2026_05"
+    assert captured["expected_files"] == ["cdna.fa.bgz"]
+    assert "ftp_dumps_geneset" in captured["resource_label"]
+
+
+def test_check_ftp_resource_fails_with_clear_message_when_dataset_missing(monkeypatch):
+    def _fake_get_ftp_paths(metadata_uri, taxonomy_uri, genome_uuid):
+        return [{"dataset_type": "genebuild", "path": "species/path/geneset/2026_05"}]
+
+    monkeypatch.setattr(ftp_checks, "get_ftp_paths", _fake_get_ftp_paths)
+
+    with pytest.raises(AssertionError, match="Dataset type 'assembly' not found"):
+        ftp_checks._check_ftp_resource(
+            user_cli=_DummyCli({
+                "--database": "sqlite:///metadata.db",
+                "--taxonomy_database": "sqlite:///taxonomy.db",
+            }),
+            genomes={"genome_uuid": "uuid-1"},
+            automation_resource_config={
+                "ftp_dumps_genomes": {
+                    "base_path": "/base",
+                    "expected_files": ["unmasked.fa.bgz"],
+                }
+            },
+            resource_key="ftp_dumps_genomes",
+            dataset_name="assembly",
+        )

--- a/tests/test_automation_genome_browser_files_expected_files.py
+++ b/tests/test_automation_genome_browser_files_expected_files.py
@@ -1,0 +1,157 @@
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for genome browser automation checks."""
+
+from pathlib import Path
+
+import pytest
+
+from ensembl.datacheck.checks.automation.automation_genome_browser_files_expected_files import (
+    _resolve_genome_browser_relative_path,
+    _validate_only_allowed_genome_browser_extensions,
+    _validate_required_genome_browser_extensions_present,
+)
+
+
+def test_resolve_genome_browser_relative_path_supports_direct_layout(tmp_path):
+    genome_uuid = "6f93d0b5-3660-414e-8cda-6caf5df23371"
+    (tmp_path / "release_22" / genome_uuid).mkdir(parents=True)
+
+    relative_path = _resolve_genome_browser_relative_path(
+        base_path=str(tmp_path),
+        release_name=22,
+        genome_uuid=genome_uuid,
+    )
+
+    assert relative_path == Path("release_22") / genome_uuid
+
+
+def test_resolve_genome_browser_relative_path_supports_one_level_nested_layout(tmp_path):
+    genome_uuid = "6f93d0b5-3660-414e-8cda-6caf5df23371"
+    (tmp_path / "release_22" / "22_4" / genome_uuid).mkdir(parents=True)
+
+    relative_path = _resolve_genome_browser_relative_path(
+        base_path=str(tmp_path),
+        release_name=22,
+        genome_uuid=genome_uuid,
+    )
+
+    assert relative_path == Path("release_22") / "22_4" / genome_uuid
+
+
+def test_resolve_genome_browser_relative_path_fails_on_multiple_nested_matches(tmp_path):
+    genome_uuid = "6f93d0b5-3660-414e-8cda-6caf5df23371"
+    (tmp_path / "release_22" / "22_0" / genome_uuid).mkdir(parents=True)
+    (tmp_path / "release_22" / "22_1" / genome_uuid).mkdir(parents=True)
+
+    with pytest.raises(AssertionError, match="Multiple genome_browser_files directories found"):
+        _resolve_genome_browser_relative_path(
+            base_path=str(tmp_path),
+            release_name=22,
+            genome_uuid=genome_uuid,
+        )
+
+
+def test_validate_only_allowed_genome_browser_extensions_passes_for_allowed_files(tmp_path):
+    resource_relative = Path("release_22") / "22_4" / "6f93d0b5-3660-414e-8cda-6caf5df23371"
+    resource_path = tmp_path / resource_relative
+    resource_path.mkdir(parents=True)
+
+    allowed_files = [
+        "chrom.hashes",
+        "chrom.hashes.ncd",
+        "chrom.sizes",
+        "chrom.sizes.ncd",
+        "contigs.bb",
+        "contigs.bed",
+        "gc.bw",
+        "gc.wig",
+        "genome_report.txt",
+        "jump.ncd",
+        "jump.txt",
+        "repeats.dust.bb",
+        "repeats.dust.bed",
+        "repeats.repeatdetector.bb",
+        "repeats.repeatdetector.bed",
+        "repeats.trf.bb",
+        "repeats.trf.bed",
+        "simple-features.bb",
+        "simple-features.bed",
+        "transcripts.bb",
+        "transcripts.bed",
+    ]
+    for file_name in allowed_files:
+        (resource_path / file_name).touch()
+
+    _validate_only_allowed_genome_browser_extensions(
+        base_path=str(tmp_path),
+        relative_path=resource_relative,
+        resource_label="genome_browser_files",
+    )
+
+
+def test_validate_only_allowed_genome_browser_extensions_fails_on_disallowed_file(tmp_path):
+    resource_relative = Path("release_22") / "22_4" / "6f93d0b5-3660-414e-8cda-6caf5df23371"
+    resource_path = tmp_path / resource_relative
+    resource_path.mkdir(parents=True)
+
+    (resource_path / "chrom.hashes").touch()
+    (resource_path / "unexpected.json").touch()
+
+    with pytest.raises(AssertionError, match="Unexpected genome_browser_files files with disallowed extensions"):
+        _validate_only_allowed_genome_browser_extensions(
+            base_path=str(tmp_path),
+            relative_path=resource_relative,
+            resource_label="genome_browser_files",
+        )
+
+
+def test_validate_required_genome_browser_extensions_fails_when_extension_missing(tmp_path):
+    resource_relative = Path("release_22") / "22_4" / "6f93d0b5-3660-414e-8cda-6caf5df23371"
+    resource_path = tmp_path / resource_relative
+    resource_path.mkdir(parents=True)
+
+    files_missing_wig = [
+        "chrom.hashes",
+        "chrom.hashes.ncd",
+        "chrom.sizes",
+        "chrom.sizes.ncd",
+        "contigs.bb",
+        "contigs.bed",
+        "gc.bw",
+        "genome_report.txt",
+        "jump.ncd",
+        "jump.txt",
+        "repeats.dust.bb",
+        "repeats.dust.bed",
+        "repeats.repeatdetector.bb",
+        "repeats.repeatdetector.bed",
+        "repeats.trf.bb",
+        "repeats.trf.bed",
+        "simple-features.bb",
+        "simple-features.bed",
+        "transcripts.bb",
+        "transcripts.bed",
+    ]
+    for file_name in files_missing_wig:
+        (resource_path / file_name).touch()
+
+    with pytest.raises(AssertionError, match="Missing genome_browser_files required file extensions"):
+        _validate_required_genome_browser_extensions_present(
+            base_path=str(tmp_path),
+            relative_path=resource_relative,
+            resource_label="genome_browser_files",
+        )

--- a/tests/test_automation_refget_expected_files.py
+++ b/tests/test_automation_refget_expected_files.py
@@ -1,0 +1,114 @@
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for refget automation checks."""
+
+from pathlib import Path
+
+import pytest
+
+from ensembl.datacheck.checks.automation.automation_refget_expected_files import (
+    _resolve_refget_relative_path,
+    _validate_only_expected_refget_files,
+)
+
+REFGET_EXPECTED_FILES = [
+    "cdna.hashes",
+    "cds.hashes",
+    "chrom.hashes",
+    "pep.hashes",
+    "seqs/cdna.txt.zst",
+    "seqs/cds.txt.zst",
+    "seqs/pep.txt.zst",
+    "seqs/seq.txt.zst",
+]
+
+
+def test_resolve_refget_relative_path_supports_direct_layout(tmp_path):
+    genome_uuid = "6f93d0b5-3660-414e-8cda-6caf5df23371"
+    (tmp_path / "release_22" / genome_uuid).mkdir(parents=True)
+
+    relative_path = _resolve_refget_relative_path(
+        base_path=str(tmp_path),
+        release_name=22,
+        genome_uuid=genome_uuid,
+    )
+
+    assert relative_path == Path("release_22") / genome_uuid
+
+
+def test_resolve_refget_relative_path_supports_one_level_nested_layout(tmp_path):
+    genome_uuid = "6f93d0b5-3660-414e-8cda-6caf5df23371"
+    (tmp_path / "release_22" / "22_4" / genome_uuid).mkdir(parents=True)
+
+    relative_path = _resolve_refget_relative_path(
+        base_path=str(tmp_path),
+        release_name=22,
+        genome_uuid=genome_uuid,
+    )
+
+    assert relative_path == Path("release_22") / "22_4" / genome_uuid
+
+
+def test_resolve_refget_relative_path_fails_on_multiple_nested_matches(tmp_path):
+    genome_uuid = "6f93d0b5-3660-414e-8cda-6caf5df23371"
+    (tmp_path / "release_22" / "22_0" / genome_uuid).mkdir(parents=True)
+    (tmp_path / "release_22" / "22_1" / genome_uuid).mkdir(parents=True)
+
+    with pytest.raises(AssertionError, match="Multiple refget directories found"):
+        _resolve_refget_relative_path(
+            base_path=str(tmp_path),
+            release_name=22,
+            genome_uuid=genome_uuid,
+        )
+
+
+def test_validate_only_expected_refget_files_passes_when_exact_match(tmp_path):
+    resource_relative = Path("release_22") / "22_4" / "6f93d0b5-3660-414e-8cda-6caf5df23371"
+    resource_path = tmp_path / resource_relative
+    resource_path.mkdir(parents=True)
+
+    for expected_file in REFGET_EXPECTED_FILES:
+        file_path = resource_path / expected_file
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.touch()
+
+    _validate_only_expected_refget_files(
+        base_path=str(tmp_path),
+        relative_path=resource_relative,
+        expected_files=REFGET_EXPECTED_FILES,
+        resource_label="refget",
+    )
+
+
+def test_validate_only_expected_refget_files_fails_when_extra_file_exists(tmp_path):
+    resource_relative = Path("release_22") / "22_4" / "6f93d0b5-3660-414e-8cda-6caf5df23371"
+    resource_path = tmp_path / resource_relative
+    resource_path.mkdir(parents=True)
+
+    for expected_file in REFGET_EXPECTED_FILES:
+        file_path = resource_path / expected_file
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.touch()
+
+    (resource_path / "seqs" / "unexpected.txt").touch()
+
+    with pytest.raises(AssertionError, match="Unexpected refget files"):
+        _validate_only_expected_refget_files(
+            base_path=str(tmp_path),
+            relative_path=resource_relative,
+            expected_files=REFGET_EXPECTED_FILES,
+            resource_label="refget",
+        )

--- a/tests/test_automation_track_api_load.py
+++ b/tests/test_automation_track_api_load.py
@@ -1,0 +1,98 @@
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from ensembl.datacheck.checks.automation import conftest as automation_conftest
+from ensembl.datacheck.checks.automation import automation_track_api_load
+
+
+class _DummyRequest:
+    def __init__(self, param):
+        self.param = param
+
+
+def test_track_api_resource_returns_configured_uri():
+    resource_config = {
+        "track_api_stage": {
+            "ignore": "False",
+            "uri": "https://example.org",
+        }
+    }
+
+    uri = automation_conftest.track_api_resource.__wrapped__(
+        _DummyRequest("track_api_stage"),
+        resource_config,
+    )
+
+    assert uri == "https://example.org"
+
+
+def test_track_api_resource_skips_ignored_resource():
+    resource_config = {
+        "track_api_stage": {
+            "ignore": "True",
+            "uri": "https://example.org",
+        }
+    }
+
+    with pytest.raises(pytest.skip.Exception):
+        automation_conftest.track_api_resource.__wrapped__(
+            _DummyRequest("track_api_stage"),
+            resource_config,
+        )
+
+
+def test_get_track_category_ids_finds_expected_categories():
+    payload = {
+        "track_categories": [
+            {
+                "label": "Genes & transcripts",
+                "track_category_id": "genes-transcripts",
+                "type": "Genomic",
+                "track_list": [],
+            },
+            {
+                "label": "Assembly",
+                "track_category_id": "assembly",
+                "type": "Genomic",
+                "track_list": [],
+            },
+        ]
+    }
+
+    category_ids = automation_track_api_load._get_track_category_ids(payload)
+
+    assert automation_track_api_load.EXPECTED_TRACK_CATEGORY_IDS.issubset(category_ids)
+
+
+def test_get_track_category_ids_reports_missing_expected_category():
+    payload = {
+        "track_categories": [
+            {
+                "label": "Assembly",
+                "track_category_id": "assembly",
+                "type": "Genomic",
+                "track_list": [],
+            },
+        ]
+    }
+
+    category_ids = automation_track_api_load._get_track_category_ids(payload)
+    missing_category_ids = (
+        automation_track_api_load.EXPECTED_TRACK_CATEGORY_IDS - category_ids
+    )
+
+    assert missing_category_ids == {"genes-transcripts"}


### PR DESCRIPTION
Add automation datachecks for vep path  and Track API



- Added automation check run instructions in checks/automation/README.md.
- Added Track API datachecks for staging and production:
- validates track_categories endpoint returns HTTP 200
- validates required category IDs exist: genes-transcripts and assembly
- Added track_api_stage and track_api_prod resource config entries.
- Improved FTP expected-file checks:
- supports metadata public path records returned as list or dict
- adds clearer errors for missing metadata/taxonomy DB options
- fixes VEP FTP paths using VEP-specific metadata locations
- Updated BLAST and genesearch checks to include release-specific paths.
- Improved refget and genome browser checks:
- supports direct and one-level nested release directory layouts
- validates unexpected refget files
- validates allowed/required genome browser file extensions
- Updated metadata helper filtering to accept both comma-separated strings and list inputs for genome UUIDs/releases.
- Added unit/integration coverage for FTP, refget, genome browser, Track API, and metadata helper behaviour.